### PR TITLE
書籍の内容に合わせて関数名を修正

### DIFF
--- a/04-typescript/05-advanced/extends.ts
+++ b/04-typescript/05-advanced/extends.ts
@@ -1,4 +1,4 @@
-const merge = <T, U extends T>(obj1: T, obj2: U): T & U => ({
+const override = <T, U extends T>(obj1: T, obj2: U): T & U => ({
   ...obj1,
   ...obj2,
 });


### PR DESCRIPTION
関数式のほうで付与している名前 `merge` と、呼び出している箇所で指定している名前 `override` が一致してなくてエラーになっていたので、書籍のほうに記載されているとおりにの関数名を `override` に修正しました。