### PR TITLE
fixed 4-6 result type

### DIFF
--- a/04-typescript/06-type-guard/result-type.ts
+++ b/04-typescript/06-type-guard/result-type.ts
@@ -20,6 +20,8 @@ export const withResult = <T, A extends any[], E extends Error>(
   } catch (error) {
     if (error instanceof Error) {
       return new Err(error as E);
+    } else {
+      return new Err(new Error() as E);
     }
   }
 };


### PR DESCRIPTION
```typescript
catch (error) {
    if (error instanceof Error) {
      return new Err(error as E);
    }
```

のif文がfalseの場合にundefinedを返すためコンパイルエラーとなっていました。